### PR TITLE
Added sequencer line 16 to reset the fixed pattern generator

### DIFF
--- a/run5/FP_E2V_2s_ir2_v26.seq
+++ b/run5/FP_E2V_2s_ir2_v26.seq
@@ -47,6 +47,7 @@
     TRG: 12  # ADC sampling trigger
     SOI: 13  # Start of image
     EOI: 14  # End of image
+    PAT: 16  # Reset of Pattern Generator (test mode)
 
 [pointers]  # can define a pointer to a function or to a repetition number (for subroutines or functions)
     #- parameters defining serial readout (columns)
@@ -76,10 +77,10 @@
 
 [functions]
      Default:  # Default state when not operating
-      clocks:          P1, P2, P3, P4, S1, S2, S3, RG, CL, RST
+      clocks:          P1, P2, P3, P4, S1, S2, S3, RG, CL, RST, PAT
       slices:
-       500 ns        =  0,  1,  1,  0,  1,  1,  0,  1,  1,   1
-       500 ns        =  0,  1,  1,  0,  1,  1,  0,  1,  1,   1
+       500 ns        =  0,  1,  1,  0,  1,  1,  0,  1,  1,   1,  0
+       500 ns        =  0,  1,  1,  0,  1,  1,  0,  1,  1,   1,  0
 
      TransferLine:  # Single line transfer (RG TBV)
       clocks:          P1, P2, P3, P4, RG
@@ -137,11 +138,11 @@
       constants:      P2=1, P3=1
 
     StartOfImage:  # Signals start of frame to be recorded (5000 ns)
-      clocks:         SOI
+      clocks:         SOI, PAT
       slices:
-        4800 ns     = 0  # lets ADC finish previous conversion and transfer
-        100 ns      = 1
-        100 ns      = 0
+        4800 ns     = 0,   0  # lets ADC finish previous conversion and transfer
+        100 ns      = 1,   1
+        100 ns      = 0,   0
       constants:    P2=1, P3=1, S1=1, S2=1, RG=1
 
     EndOfImage:  # Signals end of frame to be recorded (5000 ns)

--- a/run5/FP_ITL_2s_ir2_v26.seq
+++ b/run5/FP_ITL_2s_ir2_v26.seq
@@ -44,6 +44,7 @@
     TRG: 12  # ADC sampling trigger
     SOI: 13  # Start of image
     EOI: 14  # End of image
+    PAT: 16  # Reset of Pattern Generator (test mode)
 
 [pointers]  # can define a pointer to a function or to a repetition number (for subroutines or functions)
     #- parameters defining serial readout (columns)
@@ -73,10 +74,10 @@
 
 [functions]
     Default:  # Default state when not operating
-      clocks:          P1, P2, P3, S1, S2, S3, RG, CL, RST
+      clocks:          P1, P2, P3, S1, S2, S3, RG, CL, RST, PAT
       slices:
-       500 ns        =  1,  1,  0,  1,  1,  0,  1,  1,   1
-       500 ns        =  1,  1,  0,  1,  1,  0,  1,  1,   1
+       500 ns        =  1,  1,  0,  1,  1,  0,  1,  1,   1,   0
+       500 ns        =  1,  1,  0,  1,  1,  0,  1,  1,   1,   0
 
     TransferLine:  # Single line transfer
       clocks:          P1, P2, P3, RG, S2
@@ -131,11 +132,11 @@
        constants: P1=1,P2=1
 
     StartOfImage:  # Signals start of frame to be recorded
-      clocks:         SOI
+      clocks:         SOI, PAT
       slices:
-        4800 ns     = 0  # lets ADC finish previous conversion and transfer
-        100 ns      = 1
-        100 ns      = 0
+        4800 ns     = 0,   0  # lets ADC finish previous conversion and transfer
+        100 ns      = 1,   1
+        100 ns      = 0,   0
       constants:    P1=1, P2=1, S1=1, RST=1, RG=1
 
     EndOfImage:  # Signals end of frame to be recorded


### PR DESCRIPTION
and set it to reset with every SOI.

The Sequencer has a mode where it will generate a fixed pattern of data and present it to the DAQ while ignoring the output of the ADCs. The acquisition of data and conversion is not affected in this mode. The mode is accessed by writing 1 to address 0x400006. This change to the sequencer doesn't change any of this, however.

This change is to send a reset to the pattern generating engine with every SOI. This results in every image containing the _same_ fixed pattern. For our immediate testing needs, this is more useful than to have the pattern change from image to image.