### PR TITLE
Tickets/lsstcam 5

### DIFF
--- a/run7/FP_E2V_2s_l3cp_v28.seq
+++ b/run7/FP_E2V_2s_l3cp_v28.seq
@@ -29,7 +29,7 @@
     ISO2:             320 ns   # Time between S3 down and start of ASPIC RU
     FlushS:           520 ns   # Base serial flushing (to match ReadPixel)
     clockperiod:       10 ns   # FPGA clock period (required by the interpreter)
-    SlowTimeP:    1000000 ns   # 4 per row in SlowFlush for ~few sec/flush
+    SlowTimeP:     500000 ns   # 8 per row in SlowFlush for ~few sec/flush
     InvertCnt:       3000      # repeat count for clock invert (1 us/call)
 
 [clocks]  # clock channels
@@ -226,10 +226,14 @@
          200 ns       = 1,  0,  0,  1,  0,  1,  1,  0,  1   #   +200 ns = 18200
          TimeSS       = 1,  1,  0,  1,  0,  1,  1,  0,  0   #  +6000 ns = 24200
          TimeSS       = 1,  1,  0,  0,  0,  1,  1,  0,  0   #  +6000 ns = 30200
-         SlowTimeP    = 1,  1,  1,  0,  0,  0,  1,  1,  0   #  +4*SlowTimeP
+         SlowTimeP    = 1,  1,  1,  0,  0,  0,  1,  1,  0   #  +8*SlowTimeP
+         SlowTimeP    = 1,  1,  1,  0,  0,  0,  1,  1,  0
+         SlowTimeP    = 1,  1,  1,  0,  1,  0,  0,  1,  0
          SlowTimeP    = 1,  1,  1,  0,  1,  0,  0,  1,  0
          SlowTimeP    = 1,  1,  1,  0,  1,  1,  0,  0,  0
-         SlowTimeP    = 1,  1,  1,  0,  0,  1,  1,  0,  0   # 4*STP+5*TSS+200
+         SlowTimeP    = 1,  1,  1,  0,  1,  1,  0,  0,  0
+         SlowTimeP    = 1,  1,  1,  0,  0,  1,  1,  0,  0
+         SlowTimeP    = 1,  1,  1,  0,  0,  1,  1,  0,  0   # 8*STP+5*TSS+200
       constants:    RST=1
 
     ClkInvert: # State for clock inversion, nominal 1us

--- a/run7/FP_ITL_2s_l3cp_v28.seq
+++ b/run7/FP_ITL_2s_l3cp_v28.seq
@@ -25,7 +25,7 @@
     FlushS:          500 ns   # Base element of serial flush
     RampTime:        380 ns   # ASPIC ramp time
     TimeC:           200 ns   # clamp time
-    SlowTimeP:    800000 ns   # 5 per row in SlowFlush for ~few sec/flush
+    SlowTimeP:    400000 ns   # 5 per row in SlowFlush for ~few sec/flush
     clockperiod:      10 ns   # FPGA clock period (required by the interpreter)
     InvertCnt:      3000      # repeat count for pseudo clock invert (matching e2v's)
 
@@ -222,10 +222,15 @@
          200 ns      = 1,  0,  1,  0,  1,  1,  0,  1   #  200 ns  =
          TimeSS      = 1,  1,  1,  0,  1,  1,  0,  0   # xxxx ns  =
          SlowTimeP   = 1,  1,  1,  0,  0,  1,  0,  0
+         SlowTimeP   = 1,  1,  1,  0,  0,  1,  0,  0
+         SlowTimeP   = 1,  1,  1,  0,  0,  1,  1,  0
          SlowTimeP   = 1,  1,  1,  0,  0,  1,  1,  0
          SlowTimeP   = 1,  1,  1,  0,  0,  0,  1,  0
+         SlowTimeP   = 1,  1,  1,  0,  0,  0,  1,  0
          SlowTimeP   = 1,  1,  1,  0,  1,  0,  1,  0
-         SlowTimeP   = 1,  1,  1,  0,  1,  0,  0,  0   # 5*STP+5*TSS+200
+         SlowTimeP   = 1,  1,  1,  0,  1,  0,  1,  0
+         SlowTimeP   = 1,  1,  1,  0,  1,  0,  0,  0
+         SlowTimeP   = 1,  1,  1,  0,  1,  0,  0,  0   # 10*STP+5*TSS+200
       constants:    RST=1
 
     ClkNoInvert: # Matching e2v but w/out inversion, 1us


### PR DESCRIPTION
This fix a long standing issue with a time slice parameter above 65536. The function that used this parameter was not used in run6 , so this change will have no impact at this stage ...but at least if the function **SlowFlush** is used in the future it will do what it is supposed to do . 
We propose to do this change now to start the run7/work at summit  with a fully correct sequencer . 